### PR TITLE
Fix: Remove internal navigation from matematica.html

### DIFF
--- a/recursos/plataformas/matematica.html
+++ b/recursos/plataformas/matematica.html
@@ -18,14 +18,6 @@
       <li><a href="../../sobre.html">Sobre o Nexus</a></li>
     </ul>
   </nav>
-  <nav class="resource-internal-nav">
-    <ul>
-      <li><a href="../../index.html" class="nav-button">Página Inicial</a></li>
-      <li><a href="../../recursos.html" class="nav-button">Recursos</a></li>
-      <li><a href="../../plataformas_recursos.html" class="nav-button">Plataformas</a></li>
-      <li><strong>Matemática</strong></li>
-    </ul>
-  </nav>
   <div class="container">
     <h1>Plataformas & Ferramentas de Matemática</h1>
     <p>Descubra as melhores plataformas e ferramentas online para auxiliar seus estudos em Matemática, desde o básico até o avançado.</p>


### PR DESCRIPTION
This commit removes the <nav class="resource-internal-nav"> element from the `recursos/plataformas/matematica.html` page as per your request. This element was a secondary navigation bar.